### PR TITLE
feat: throw error when no records are found

### DIFF
--- a/src/aneel.gateway.ts
+++ b/src/aneel.gateway.ts
@@ -115,6 +115,10 @@ export class AneelGateway {
         try {
             const acionamentos = await this._listarBandeirasTarifariasAcionamentos();
 
+            if (acionamentos.length === 0) {
+                throw new Error("Nenhum acionamento de bandeira tarifária encontrado.");
+            }
+
             await this.cache?.set(cacheKey, acionamentos);
 
             return acionamentos;
@@ -220,6 +224,10 @@ export class AneelGateway {
                 subClasse,
                 sigAgente,
             );
+
+            if (tarifas.length === 0) {
+                throw new Error("Nenhuma tarifa encontrada.");
+            }
 
             await this.cache?.set(cacheKey, tarifas);
 


### PR DESCRIPTION
A API dos dados da ANEEL está retornando um array vazio nos records; Como o request está sendo executado com sucesso o cache não é consultado nessa situação.

```ts
{
  help: 'https://dadosabertos.aneel.gov.br/api/3/action/help_show?name=datastore_search',
  success: true,
  result: {
    include_total: true,
    limit: 100,
    offset: 0,
    records_format: 'objects',
    resource_id: '0591b8f6-fe54-437b-b72b-1aa2efd46e42',
    total_estimation_threshold: null,
    records: [],
    fields: [ [Object], [Object], [Object], [Object], [Object] ],
    _links: {
      start: '/api/3/action/datastore_search?resource_id=0591b8f6-fe54-437b-b72b-1aa2efd46e42&limit=100',
      next: '/api/3/action/datastore_search?resource_id=0591b8f6-fe54-437b-b72b-1aa2efd46e42&limit=100&offset=100'
    },
    total: 0,
    total_was_estimated: false
  }
}
```

Foi adicionado uma verificação no tamanho do array com um throw para que o cache seja consultado